### PR TITLE
Update moment-timezone

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,6 @@
     "angular-messages": "1.3.15",
     "modernizr": "~2.8.3",
     "moment": "~2.10.3",
-    "moment-timezone": "~0.4.0"
+    "moment-timezone": "~0.5.13"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -32,5 +32,8 @@
     "modernizr": "~2.8.3",
     "moment": "~2.10.3",
     "moment-timezone": "~0.5.13"
+  },
+  "resolutions": {
+    "angular": "1.3.15"
   }
 }


### PR DESCRIPTION
0.5.13 includes data from 2012 to 2022
ticket: https://opentable.atlassian.net/browse/GCW-818